### PR TITLE
feat(logcat): link severity highlights to Diagnostic groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project adheres to SemVer.
 
 ## [Unreleased]
 
+### Changed
+
+- Logcat severity highlights now default-link to Neovim diagnostic highlight
+  groups so colorschemes can style them consistently without plugin-specific
+  overrides.
+
 ## [0.6.0] - 2026-03-25
 
 ### Added

--- a/lua/android/logcat/highlight.lua
+++ b/lua/android/logcat/highlight.lua
@@ -7,6 +7,12 @@ local LEVEL_GROUPS = {
   I = "AndroidLogcatInfo",
   D = "AndroidLogcatDebug",
 }
+local HIGHLIGHT_LINKS = {
+  { group = "AndroidLogcatError", link = "DiagnosticError" },
+  { group = "AndroidLogcatWarn", link = "DiagnosticWarn" },
+  { group = "AndroidLogcatInfo", link = "DiagnosticInfo" },
+  { group = "AndroidLogcatDebug", link = "DiagnosticHint" },
+}
 
 local function detect_level(line)
   if type(line) ~= "string" then
@@ -16,10 +22,12 @@ local function detect_level(line)
 end
 
 function M.setup()
-  vim.api.nvim_set_hl(0, "AndroidLogcatError", { fg = "Red" })
-  vim.api.nvim_set_hl(0, "AndroidLogcatWarn", { fg = "Yellow" })
-  vim.api.nvim_set_hl(0, "AndroidLogcatInfo", { fg = "Blue" })
-  vim.api.nvim_set_hl(0, "AndroidLogcatDebug", { fg = "Green" })
+  for _, highlight_link in ipairs(HIGHLIGHT_LINKS) do
+    vim.api.nvim_set_hl(0, highlight_link.group, {
+      default = true,
+      link = highlight_link.link,
+    })
+  end
 end
 
 function M.clear(buf)

--- a/lua/tests/android/logcat/highlight_test.lua
+++ b/lua/tests/android/logcat/highlight_test.lua
@@ -1,0 +1,53 @@
+local M = {}
+
+local assert = require("tests.helpers.assert")
+local highlight = require("android.logcat.highlight")
+
+local GROUPS = {
+  "AndroidLogcatError",
+  "AndroidLogcatWarn",
+  "AndroidLogcatInfo",
+  "AndroidLogcatDebug",
+}
+
+local function clear_groups()
+  for _, group in ipairs(GROUPS) do
+    vim.api.nvim_set_hl(0, group, {})
+  end
+end
+
+local function assert_link(group, expected)
+  local definition = vim.api.nvim_get_hl(0, { name = group, link = true })
+
+  assert.eq(definition.link, expected, group .. " link")
+end
+
+local function links_log_levels_to_diagnostic_groups()
+  clear_groups()
+
+  highlight.setup()
+
+  assert_link("AndroidLogcatError", "DiagnosticError")
+  assert_link("AndroidLogcatWarn", "DiagnosticWarn")
+  assert_link("AndroidLogcatInfo", "DiagnosticInfo")
+  assert_link("AndroidLogcatDebug", "DiagnosticHint")
+end
+
+local function preserves_user_highlight_overrides()
+  clear_groups()
+  vim.api.nvim_set_hl(0, "AndroidLogcatError", { fg = "#123456" })
+
+  highlight.setup()
+
+  local definition = vim.api.nvim_get_hl(0, { name = "AndroidLogcatError", link = true })
+
+  assert.eq(definition.link, nil, "override link")
+  assert.eq(definition.fg, tonumber("123456", 16), "override fg")
+end
+
+function M.run()
+  links_log_levels_to_diagnostic_groups()
+  preserves_user_highlight_overrides()
+end
+
+return M


### PR DESCRIPTION
## Summary

Logcat already has the same basic severity shape as diagnostics: error, warn, info, debug. The plugin was coloring those with hardcoded named colors (`Red`, `Yellow`, `Blue`, `Green`), which can look off depending on the user's colorscheme.

This PR links the default logcat severity groups to Neovim's diagnostic groups:

- `AndroidLogcatError` -> `DiagnosticError`
- `AndroidLogcatWarn` -> `DiagnosticWarn`
- `AndroidLogcatInfo` -> `DiagnosticInfo`
- `AndroidLogcatDebug` -> `DiagnosticHint`

These are default links, so user-defined `AndroidLogcat*` highlights are left alone.

## What changed

Logcat severity colors now come from the active colorscheme's diagnostic palette instead of fixed named colors. Users who want their own logcat colors can still set the `AndroidLogcat*` groups directly.

## Testing

- `./scripts/run-tests.sh tests.android.logcat.highlight_test`
- `./scripts/run-tests.sh`
- Tested manually in Now in Android with `:AndroidLogcat` and adb-emitted E/W/I/D log lines
