### PR TITLE
fixed windows adb not found issue

### DIFF
--- a/lua/android/sdk/discovery.lua
+++ b/lua/android/sdk/discovery.lua
@@ -288,7 +288,7 @@ function M.new(opts)
   local config = opts and opts.config or nil
   local root = opts and opts.root or nil
   local cwd = opts and opts.cwd or nil
-  local os_name = opts and opts.os_name or nil
+  local os_name = opts and opts.os_name or vim.loop.os_uname().sysname
   local home = opts and opts.home or nil
   local discovery = {}
 

--- a/lua/tests/android/sdk/discovery_test.lua
+++ b/lua/tests/android/sdk/discovery_test.lua
@@ -153,6 +153,34 @@ local function locates_sdk_tools_on_windows()
   assert.eq(tools.adb, "C:/Sdk/platform-tools/adb.exe", "adb windows")
 end
 
+local function auto_detects_windows_tool_extensions()
+  local original_uname = vim.loop.os_uname
+  vim.loop.os_uname = function()
+    return { sysname = "Windows_NT" }
+  end
+
+  local store = require("android.state.store").new()
+  local discovery = require("android.sdk.discovery").new({
+    env = { ANDROID_SDK_ROOT = "C:/Sdk" },
+    exists = function(path)
+      local matches = {
+        ["C:/Sdk"] = true,
+        ["C:/Sdk/cmdline-tools/latest/bin/sdkmanager.bat"] = true,
+        ["C:/Sdk/cmdline-tools/latest/bin/avdmanager.bat"] = true,
+        ["C:/Sdk/emulator/emulator.exe"] = true,
+        ["C:/Sdk/platform-tools/adb.exe"] = true,
+      }
+      return matches[path] or false
+    end,
+    store = store,
+  })
+
+  local tools = discovery.tools()
+  assert.eq(tools.adb, "C:/Sdk/platform-tools/adb.exe", "auto-detected adb windows")
+
+  vim.loop.os_uname = original_uname
+end
+
 local function falls_back_to_tools_bin()
   local store = require("android.state.store").new()
   local discovery = require("android.sdk.discovery").new({
@@ -236,6 +264,7 @@ function M.run()
   uses_default_sdk_candidates()
   locates_sdk_tools()
   locates_sdk_tools_on_windows()
+  auto_detects_windows_tool_extensions()
   falls_back_to_cmdline_tools_bin()
   falls_back_to_tools_bin()
   locates_aapt2_from_build_tools()


### PR DESCRIPTION
# Summary
fixed https://github.com/iamironz/android-nvim-plugin/issues/6
## Changes
Set platform to default to vim.loop.os_uname().sysname if not specified to discovery.
## Testing

- [x] `./scripts/run-tests.sh`
- [x] Adb is found on windows

## Docs

- [x] README updated (if needed)
- [x] docs/ updated (if needed)
- [x] docs navigation updated for moved or renamed pages
- [x] command/config behavior reflected in reference docs
- [x] user workflow changes reflected in guides
- [x] CHANGELOG updated (user-visible changes)
- [x] Config changes or new defaults noted

## Checklist

- [x] Behavior is backward compatible or clearly documented
- [x] No unrelated changes included
